### PR TITLE
CRAN fix -- remove antiword link

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -1,0 +1,40 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# See https://github.com/r-lib/actions/tree/master/examples#readme for
+# additional example workflows available for the R community.
+
+name: R
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        r-version: ['3.6.3', '4.1.1']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up R ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@f57f1301a053485946083d7a45022b278929a78a
+        with:
+          r-version: ${{ matrix.r-version }}
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+      - name: Check
+        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "error")
+        shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,6 @@ Imports: antiword, curl, data.table, pdftools, readxl, rvest, striprtf, textshap
 License: GPL-2
 LazyData: TRUE
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 BugReports: https://github.com/trinker/textreadr/issues?state=open
 URL: https://github.com/trinker/textreadr

--- a/R/read_doc.R
+++ b/R/read_doc.R
@@ -10,8 +10,8 @@
 #' @param trim logical.  If `TRUE` the leading/training white space is
 #' removed.
 #' @param format logical.  If `TRUE` the output will keep doc formatting
-#' (e.g., bold, italics, underlined).  This corresponds to the `-f` flag in
-#' [**antiword**](http://www.winfield.demon.nl).
+#' (e.g., bold, italics, underlined); bold text is printed like \\*bold\\*, 
+#' italics like /italics/ and underlined text as \\_underlined\\_.
 #' @param ... ignored.
 #' @return Returns a character vector.
 #' @keywords doc

--- a/man/read_doc.Rd
+++ b/man/read_doc.Rd
@@ -18,8 +18,8 @@ removed.}
 removed.}
 
 \item{format}{logical.  If \code{TRUE} the output will keep doc formatting
-(e.g., bold, italics, underlined).  This corresponds to the \code{-f} flag in
-\href{http://www.winfield.demon.nl}{\strong{antiword}}.}
+(e.g., bold, italics, underlined); bold text is printed like \\\emph{bold\\},
+italics like /italics/ and underlined text as \\\emph{underlined\\}.}
 
 \item{...}{ignored.}
 }


### PR DESCRIPTION
I have removed the link to antiword, as the link returned a 404 site. Instead, I included the description of the `-f` command from antiword.

It seems like this should be enough for the package to pass the CRAN test again. I tested for both R versions 3.6.3 and 4.1.1